### PR TITLE
Add tar to package install

### DIFF
--- a/roles/ci_setup/vars/redhat.yml
+++ b/roles/ci_setup/vars/redhat.yml
@@ -4,6 +4,7 @@ cifmw_ci_setup_packages:
   - ca-certificates
   - git-core
   - make
+  - tar
 
 cifmw_ci_setup_rhel_rhsm_default_repos:
   - 'rhel-*-baseos-rpms'


### PR DESCRIPTION
When running the "Install openshift client" task, if the target node
doesn't have tar installed the following error occurs:

```
Failed to find handler for /openshift-client-linuxpzhqp3xh.tar.gz
Make sure the required command to extract the file is installed.
Unable to find required 'gtar' or 'tar' binary in the path
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running